### PR TITLE
Update Magick.NET due to severe vulnerability warning

### DIFF
--- a/LawfulBlade/LawfulBlade.csproj
+++ b/LawfulBlade/LawfulBlade.csproj
@@ -93,7 +93,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.4.0" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.7.0" />
     <PackageReference Include="Magick.NET.SystemWindowsMedia" Version="8.0.4" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.2" />
     <PackageReference Include="System.Management" Version="9.0.2" />


### PR DESCRIPTION
dotnet raises a warning while building because the specified version of Magick.NET has a high-severity vulnerability: https://github.com/advisories/GHSA-vmhh-8rxq-fp9g