### PR TITLE
Use InvariantCulture basically everywhere we parse a number from a string

### DIFF
--- a/Extra/ParamPro/Control/FractionalBox.cs
+++ b/Extra/ParamPro/Control/FractionalBox.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -68,7 +69,7 @@ namespace ParamPro.Control
             Text = Text.TrimEnd('.');
 
             // Now attempt to parse the text as a decimal, and immediately shove it back in
-            if (decimal.TryParse(Text, out decimal result))
+            if (decimal.TryParse(Text, CultureInfo.InvariantCulture, out decimal result))
             {
                 // Clamp the result to the required range
                 result = Math.Clamp(result, MinValue, MaxValue);

--- a/LawfulBlade/App.xaml.cs
+++ b/LawfulBlade/App.xaml.cs
@@ -6,6 +6,7 @@ using LawfulBlade.Core.Extensions;
 using System.ComponentModel;
 using LawfulBlade.Core.Package;
 using System.Text.Json;
+using System.Globalization;
 
 namespace LawfulBlade
 {
@@ -174,8 +175,8 @@ namespace LawfulBlade
             if (DownloadManager.RequestVersion(new Uri(RemoteVersionURL), out versionInfo))
             {
                 // We must parse the versions as integers to do comparisons...
-                int currentVersion = int.Parse(Version.Strip('.'));
-                int newVersion     = int.Parse(versionInfo.Version.Strip('.'));
+                int currentVersion = int.Parse(Version.Strip('.'), CultureInfo.InvariantCulture);
+                int newVersion     = int.Parse(versionInfo.Version.Strip('.'), CultureInfo.InvariantCulture);
 
                 needsUpdate = currentVersion < newVersion;
 

--- a/LawfulBlade/Core/Instance/InstanceVariable.cs
+++ b/LawfulBlade/Core/Instance/InstanceVariable.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Globalization;
+using System.Text.Json.Serialization;
 
 namespace LawfulBlade.Core
 {
@@ -23,7 +24,7 @@ namespace LawfulBlade.Core
         {
             return Type switch 
             {
-                InstanceVariableType.Integer => long.Parse(Value),
+                InstanceVariableType.Integer => long.Parse(Value, CultureInfo.InvariantCulture),
                 InstanceVariableType.String  => Value,
                 InstanceVariableType.Binary  => Convert.FromBase64String(Value),
 

--- a/LawfulBlade/Core/Package/PackageManager.cs
+++ b/LawfulBlade/Core/Package/PackageManager.cs
@@ -1,5 +1,6 @@
 ﻿
 using LawfulBlade.Core.Extensions;
+using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using System.Windows.Controls.Primitives;
@@ -135,8 +136,8 @@ namespace LawfulBlade.Core.Package
                 result = Package.Load(packageBundlePath);
 
                 // Get the two versions as decimals
-                decimal oldVersion = decimal.Parse(result.Version.GetDigits());
-                decimal newVersion = decimal.Parse(foundRepoPackage.Value.Version.GetDigits());
+                decimal oldVersion = decimal.Parse(result.Version.GetDigits(), CultureInfo.InvariantCulture);
+                decimal newVersion = decimal.Parse(foundRepoPackage.Value.Version.GetDigits(), CultureInfo.InvariantCulture);
 
                 // Compare the two versions
                 if (newVersion > oldVersion)


### PR DESCRIPTION
This was causing exceptions (see: #1) to be thrown when installing packages, and probably would've come up again if it wasn't fixed globally.